### PR TITLE
ZFS configure ref to kernel sources fixed

### DIFF
--- a/build64.sh
+++ b/build64.sh
@@ -62,7 +62,7 @@ make -s -j6
 sudo make install
 
 sudo mv /lib/modules/${KVERSION}-v8/extra /lib/modules/${KVERSION}-v8+/extra
-tar -cvzf /home/pi/64-bit-zfs-modules-${KVERSION}-v8+.tar.gz /lib/modules/${KVERSION}-v8+/extra
+tar -cvzf ~/64-bit-zfs-modules-${KVERSION}-v8+.tar.gz /lib/modules/${KVERSION}-v8+/extra
 echo "Now exit the 64-bit userland, back to 32-bit userland (staying on 64-bit kernel) and run build64_part2.sh"
 
 cd "${CUR_DIR}"

--- a/build64.sh
+++ b/build64.sh
@@ -56,7 +56,7 @@ make distclean || true
 
 ./autogen.sh
 autoreconf --install --force
-./configure --with-linux=/home/pi/linux-raspberrypi-kernel_${RELEASE}
+./configure --with-linux=~/linux-raspberrypi-kernel_${RELEASE}
 
 make -s -j6
 sudo make install


### PR DESCRIPTION
If username is not pi, script will fail b/c kernel sources not in /home/pi/...